### PR TITLE
Update WebRtcRespectOsRoutingTableEnabled

### DIFF
--- a/edgeenterprise/microsoft-edge-policies.md
+++ b/edgeenterprise/microsoft-edge-policies.md
@@ -27864,7 +27864,7 @@ Use the preceding information when configuring this policy.
   
   #### Supported versions:
 
-  - On Windows since 94 or later
+  - On Windows since 96 or later
 
   #### Description
 


### PR DESCRIPTION
This change updates the availability information for
WebRtcRespectOsRoutingTableEnabled as we shipped it in Edge 96 instead
of 94.