### PR TITLE
Update edge-ie-mode-add-guidance-cookieshare.md

### DIFF
--- a/edgeenterprise/edge-ie-mode-add-guidance-cookieshare.md
+++ b/edgeenterprise/edge-ie-mode-add-guidance-cookieshare.md
@@ -90,7 +90,9 @@ The following table describes the \<shared-cookie\> element added to support the
 <shared-cookie host="subdomain.contoso.com" name="cookie3" source-engine="MSEdge"></shared-cookie> 
 </site-list> 
 ```
-
+> [!NOTE]
+> Enterprise Site List Manager doesn't support multiple cookie names with the same host value.
+> 
 ## See also
 
 - [About IE mode](./edge-ie-mode.md)


### PR DESCRIPTION
Current Enterprise Site List Manager in Edge has a limitation on the cookie sharing section where it removes duplicate host entries even though the cookie names are different. This makes having multiple cookies shared between IE11 and MSEdge impossible using Enterprise Site List Manager to manage and it needs to be handled manually post export.