### PR TITLE
Fix formatting for cloud site list mgmt doc

### DIFF
--- a/edgeenterprise/edge-ie-mode-cloud-site-list-mgmt.md
+++ b/edgeenterprise/edge-ie-mode-cloud-site-list-mgmt.md
@@ -25,7 +25,7 @@ As you transition your workflows and applications from IE11 to IE mode, **Cloud 
 
 To learn more, watch the next video.
 
-[![New Cloud Site List Management for IE mode](media/edge-ie-mode-cloud-site-list-mgmt/0.png)](https://www.youtube.com/watch?v=p3FyGvsNKC8 "New Cloud Site List Management for IE mode").
+[![New Cloud Site List Management for IE mode](media/edge-ie-mode-cloud-site-list-mgmt/0.png)](https://www.youtube.com/watch?v=p3FyGvsNKC8 "New Cloud Site List Management for IE mode")
 
 This experience lets you store your organization’s site list in a compliant cloud location instead of needing an on-premises infrastructure to host your site list. You can create, import, export site lists, and audit changes to site list entries through the Microsoft 365 Admin Center. You can publish multiple site lists to the cloud and use group policy to assign different groups of devices to use different lists.
 


### PR DESCRIPTION
Fixing the extra `.` period in the documentation. On desktop browsers, it leads the page to render incorrectly.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/67442967/173915670-e0ce0049-3e8a-4265-9209-e69cee61af1e.png">
