### PR TITLE
Fixed invalid example for the RestrictSigninToPattern setting on Windows

### DIFF
--- a/edgeenterprise/microsoft-edge-policies.md
+++ b/edgeenterprise/microsoft-edge-policies.md
@@ -27124,7 +27124,7 @@ Note that signed-in profiles with a username that doesn't match this pattern wil
   ##### Example value:
 
 ```
-".*@contoso.com"
+.*@contoso.com
 ```
 
   #### Mac information and settings


### PR DESCRIPTION
Removed the extraneous quotes from the example provided for managing the RestrictSigninToPattern setting on Windows