### PR TITLE
Expand the warning against using network locations in Edge user data dir

### DIFF
--- a/edgeenterprise/edge-learnmore-create-user-directory-vars.md
+++ b/edgeenterprise/edge-learnmore-create-user-directory-vars.md
@@ -33,7 +33,7 @@ Review the following guidance before using variables for paths.
 - To avoid errors caused by applications starting from different locations on different occasions, make sure that paths are absolute.
 - Every variable can occur only once in a path. For most of them, this is the only meaningful way to use variables, because they resolve to absolute paths.
 - Almost all policies will create the path if it doesn't exist (if possible in the existing circumstances).
-- Using network locations for some policies can lead to unexpected results due to differences in how different versions/channels of Microsoft Edge handle the folder structure.
+- Using network locations for some policies can lead to unexpected results due to differences in how different versions/channels of Microsoft Edge handle the folder structure. Moreover, network instability or directory-locking backup processes in the network location can lead to unexpected reliability issues, in the form of browser hangs or crashes.
 
 ### Supported path variables
 


### PR DESCRIPTION
Using a network location as Edge's user data directory might lead to browser hangs or crashes if the connection is unstable or the directory gets locked by other processes. Expand the warning against network locations to clarify the consequences.