### PR TITLE
Update CRL Revocation Section in microsoft-edge-security-cert-verific…

### DIFF
--- a/edgeenterprise/microsoft-edge-security-cert-verification.md
+++ b/edgeenterprise/microsoft-edge-security-cert-verification.md
@@ -77,11 +77,11 @@ If your enterprise enables the **[RequireOnlineRevocationChecksForLocalAnchors](
 
 Before Microsoft Edge 114, the new Chromium-based verifier enforces "Baseline Requirement" max ages for CRLs. For leaf revocations, the current maximum age is 7 days and for intermediate revocations, the current maximum age is 366 days. The check is performed by checking that the current time minus the "This Update" ("Effective Date") doesn't exceed those maximums. In Microsoft Edge 114, these requirements are no longer enforced for non-publicly trusted certificates. For more information, see [Chromium issue 971714](https://crbug.com/971714).
 
-Since the new verifier downloads revocation information via the browser's networking stack, HTTP Strict Transport Security (HSTS) upgrades also apply. This upgrade can create an incompatibility with the requirement that the CRL information is hosted via HTTP (not HTTPS) if the host has an HSTS pin configured. If this scenario negatively impacts your environment, we encourage you to share more information about the impact via [Chromium issue 1432246](https://crbug.com/1432246).
+For Edge version 120 and below, the built-in verifier downloads revocation information via the browser's networking stack, such that HTTP Strict Transport Security (HSTS) upgrades apply. This upgrade can create an incompatibility with the requirement that the CRL information is hosted via HTTP (not HTTPS) if the host has an HSTS pin configured. This scenario has seen been addressed and fixed. More information can be found via [Chromium issue 1432246](https://crbug.com/1432246).
 
 If you encounter `ERR_CERT_NO_REVOCATION_MECHANISM`, you should confirm that the CRL at the URI specified by the certificate returns a **DER encoded** (not PEM encoded) response.
 
-If you encounter `ERR_CERT_UNABLE_TO_CHECK_REVOCATION` errors, you should confirm that the certificate issuer is also the CRL issuer, the certificate's `cRLIssuer` field isn't set, the URI hosting the CRL both uses the HTTP protocol and isn't on a host configured to use HSTS, and that the CRL was issued recently enough.
+If you encounter `ERR_CERT_UNABLE_TO_CHECK_REVOCATION` errors, you should confirm that the certificate issuer is also the CRL issuer, the certificate's `cRLIssuer` field isn't set, and that the CRL was issued recently enough. If you are on a version of Edge 120 or below, ensure that the URI hosting the CRL both uses the HTTP protocol and isn't on a host configured to use HSTS.
 
 ## See also
 

--- a/edgeenterprise/microsoft-edge-security-cert-verification.md
+++ b/edgeenterprise/microsoft-edge-security-cert-verification.md
@@ -56,32 +56,12 @@ Examples of stricter RFC 5280 compliance include:
 2. Name constraints specifying an IP address must contain eight octets for IPv4 addresses and 32 octets for IPv6 addresses. If your certificate specifies an empty IP address, you should reissue the certificate and omit the IP address name constraint entirely.
 3. Name constraints with an empty "excluded" list is invalid. The Windows certificate viewer shows this list as `Excluded=None` within the `Name Constraints` details. For more information, see [Chromium issue 1457348](https://crbug.com/1457348) for more details. Instead of specifying an empty list, omit it entirely.
 
-### Application Policies extension
-
-Prior to Microsoft Edge 115, the new verifier doesn't support the Windows-only "application policies" extension field that's described in the [CertGetEnhancedKeyUsage function documentation](/windows/win32/api/wincrypt/nf-wincrypt-certgetenhancedkeyusage#remarks). In Microsoft Edge 115, an update was made to ignore the extension. See [Chromium issue 1439638](https://crbug.com/1439638) for more details.
-
-This extension uses the object identifier (OID) `1.3.6.1.4.1.311.21.10`. If the certificate includes this extension and marks it as critical, the connection fails with `ERR_CERT_INVALID`.
-
-You can use one of the following ways to check if this scenario applies to your certificate:
-
-1. A network log captured via `about:net-export` includes the string `ERROR: Unconsumed critical extension` in the `CERT_VERIFIER_TASK` with an OID value of `2B060104018237150A`.
-2. Open the certificate with the Windows certificate viewer. In the "Show" filter, select "Critical Extensions Only". Check to see if an "Application Policies" field in present.
-3. Run `certutil.exe` with the `-dump` switch and review the output to check for a critical Application Policies extension field.
-
-If your certificate currently uses this extension, make sure that it now works in Microsoft Edge 115. Alternatively, reissue the certificate and instead rely solely on the enhanced key usage field (OID `2.5.29.37`) to specify allowed usages.
-
 ## Known revocation checking behavior differences on Windows
 In addition to the more stringent RFC 5280 requirements, the new verifier _doesn't_ support LDAP-based certificate revocation list (CRL) URIs.
 
 If your enterprise enables the **[RequireOnlineRevocationChecksForLocalAnchors](/deployedge/microsoft-edge-policies#requireonlinerevocationchecksforlocalanchors)** policy and the CRLs aren't valid per RFC 5280, your environment may start to see `ERR_CERT_NO_REVOCATION_MECHANISM` and/or `ERR_CERT_UNABLE_TO_CHECK_REVOCATION` errors.
 
-Before Microsoft Edge 114, the new Chromium-based verifier enforces "Baseline Requirement" max ages for CRLs. For leaf revocations, the current maximum age is 7 days and for intermediate revocations, the current maximum age is 366 days. The check is performed by checking that the current time minus the "This Update" ("Effective Date") doesn't exceed those maximums. In Microsoft Edge 114, these requirements are no longer enforced for non-publicly trusted certificates. For more information, see [Chromium issue 971714](https://crbug.com/971714).
-
-For Edge version 120 and below, the built-in verifier downloads revocation information via the browser's networking stack, such that HTTP Strict Transport Security (HSTS) upgrades apply. This upgrade can create an incompatibility with the requirement that the CRL information is hosted via HTTP (not HTTPS) if the host has an HSTS pin configured. This scenario has seen been addressed and fixed. More information can be found via [Chromium issue 1432246](https://crbug.com/1432246).
-
 If you encounter `ERR_CERT_NO_REVOCATION_MECHANISM`, you should confirm that the CRL at the URI specified by the certificate returns a **DER encoded** (not PEM encoded) response.
-
-If you encounter `ERR_CERT_UNABLE_TO_CHECK_REVOCATION` errors, you should confirm that the certificate issuer is also the CRL issuer, the certificate's `cRLIssuer` field isn't set, and that the CRL was issued recently enough. If you are on a version of Edge 120 or below, ensure that the URI hosting the CRL both uses the HTTP protocol and isn't on a host configured to use HSTS.
 
 ## See also
 


### PR DESCRIPTION
…ation.md

Update the CRL Revocation Section to reflect the changes in Edge 121+, which no longer apply HSTS to AIA, OCSP, and CRL requests.